### PR TITLE
Add X509 certificate copy rest api (api/v1/cc/{serial}) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ Certificate:
 
 Once you have the serial number, you can send a status request via:
 
+### Request with `application/json` (default)
+
+You can send a status request via:
+
 ```bash
 $ curl -v --cacert certs/CA.crt  \
           --cert certs/BOOTSTRAP.crt \
@@ -298,9 +302,23 @@ $ curl -v --cacert certs/CA.crt  \
           https://MBP2021.local:1443/api/v1/cs/1648935985023194000
 ```
 
-This endpoint accepts requests in cbor (`application/cbor`) or json
-(`application/json`), defaulting to JSON responses if no Content-Type is
-provided. The response Content-Type will match the request type used.
+### Request with `application/cbor`
+
+You can send a status request via:
+
+```bash
+$ curl -v --cacert certs/CA.crt  \
+          --cert certs/BOOTSTRAP.crt \
+          --key certs/BOOTSTRAP.key  \
+          -H 'Content-Type: application/cbor' \
+          https://MBP2021.local:1443/api/v1/cs/1648935985023194000 \
+          -o cbor_enc.raw
+```
+
+> CBOR requests receive binary responses, which curl will print as an unknown 
+  symbol on the console. Pass the `-o <filename>` argument to store the binary 
+  output in a file, and execute `go run cbor_decoder.go -i <filename> -r cs`
+  to decode  the binary output response and print in the JSON format.
 
 ### Responses
 
@@ -327,12 +345,32 @@ This endpoint accepts requests in cbor (`application/cbor`) or json
 (`application/json`), defaulting to JSON responses if no Content-Type is
 provided. The response Content-Type will match the request type used.
 
+### Request with `application/json`
+
 ```bash
 $ curl -v --cacert certs/CA.crt  \
           --cert certs/BOOTSTRAP.crt \
           --key certs/BOOTSTRAP.key  \
           https://MBP2021.local:1443/api/v1/ds/56d38f73-3f6f-4a59-86bc-d315a1ccc634
 ```
+
+### Request with `application/cbor`
+
+You can send a status request via:
+
+```bash
+$ curl -v --cacert certs/CA.crt  \
+          --cert certs/BOOTSTRAP.crt \
+          --key certs/BOOTSTRAP.key  \
+          -H 'Content-Type: application/cbor' \
+          https://MBP2021.local:1443/api/v1/ds/56d38f73-3f6f-4a59-86bc-d315a1ccc634 \
+          -o cbor_enc.raw
+```
+
+> CBOR requests receive binary responses, which curl will print as an unknown 
+  symbol on the console. Pass the `-o <filename>` argument to store the binary 
+  output in a file, and execute `go run cbor_decoder.go -i <filename> -r ds`
+  to decode  the binary output response and print in the JSON format.
 
 ### Responses
 
@@ -356,7 +394,7 @@ key or the current subject public key.
 
 Requests the revocation of an existing certificate registration.
 
-## `api/v1/ccs` Clous Connectvity Settings: **GET**
+## `api/v1/ccs` Cloud Connectvity Settings: **GET**
 
 Requests the cloud connectivity details for the MQTT broker associated with
 your cloud infrastructure.
@@ -371,22 +409,14 @@ $ curl -v --cacert certs/CA.crt  \
           --key certs/BOOTSTRAP.key  \
           -H 'Content-Type: application/cbor' \
           -H 'Accept: application/cbor' \
-          https://MBP2021.local:1443/api/v1/ccs
+          https://MBP2021.local:1443/api/v1/ccs \
+          -o cbor_enc.raw
 ```
 
-#### Response
-
-Replies with a CBOR array containing the following fields:
-
-```cddl
-{
-   1 => tstr,  ; Hubname
-   2 => int,   ; Port
-}
-```
-
-- `Hubname` contains the Azure IoT Hub hubname string.
-- `Port` contains the Azure IoT Hub MQTT port number.
+> CBOR requests receive binary responses, which curl will print as an unknown 
+  symbol on the console. Pass the `-o <filename>` argument to store the binary 
+  output in a file, and execute `go run cbor_decoder.go -i <filename> -r ccs`
+  to decode  the binary output response and print in the JSON format.
 
 ### Request with `application/json` (default)
 
@@ -399,7 +429,7 @@ $ curl -v --cacert certs/CA.crt  \
           https://MBP2021.local:1443/api/v1/ccs
 ```
 
-#### Response
+### Response
 
 Replies with a JSON array containing the following fields:
 
@@ -412,6 +442,58 @@ Replies with a JSON array containing the following fields:
 
 - `Hubname` contains the Azure IoT Hub hubname string.
 - `Port` contains the Azure IoT Hub MQTT port number.
+
+## `api/v1/cc/{serial}` X509 Certificate Copy Request: **GET**
+
+Requests a copy of the x509 certificate associated with the supplied serial number.
+If found, the certificate data is returned in PEM format (BASE64 ASCII).
+
+If you need information about the serial number refer 
+[here](#apiv1csserial-certificate-status-request-get)
+
+### Request by default `application/json`
+
+You can send the x509 certificate copy request via:
+
+```bash
+$ curl -v --cacert certs/CA.crt  \
+          --cert certs/BOOTSTRAP.crt \
+          --key certs/BOOTSTRAP.key  \
+          https://MBP2021.local:1443/api/v1/cc/1664276589086394391
+```
+
+### Request with the `application/cbor`
+
+You can send the x509 certificate copy request via:
+
+```bash
+$ curl -v --cacert certs/CA.crt  \          
+          --cert certs/BOOTSTRAP.crt \
+          --key certs/BOOTSTRAP.key  \
+          -H 'Content-Type: application/cbor' \
+          https://MBP2021.local:1443/api/v1/cc/1664276589086394391 \
+          -o cbor_enc.raw
+```
+
+> CBOR requests receive binary responses, which curl will print as an unknown 
+  symbol on the console. Pass the `-o <filename>` argument to store the binary 
+  output in a file, and execute `go run cbor_decoder.go -i <filename> -r cc`
+  to decode  the binary output response and print in the JSON format.
+
+### Response
+
+Replies with a JSON or CBOR array containing `Status`, and `Cert` fields:
+
+- `Status` is an error code where `0` indicates success, and non-zero values
+should be treated as an error.
+- `Cert` contains the string type x509 pem format certificate.
+
+```json
+{
+  "Status":0,
+  "Cert":"-----BEGIN CERTIFICATE-----\nMIIB6TCCAY+gAwIBAgIIFxiyvXR+SBcwCgYIKoZIzj0EAwIwNTEUMBIGA1UEChML\nTGluYXJvLCBMVEQxHTAbBgNVBAMTFExSQyAtIDIwMjIwOTI3MTEwMjE3MB4XDTIy\nMDkyNzExMDMwOVoXDTIzMDkyNzExMDMwOVowfDEiMCAGA1UEChMZYXJtLXZpcnR1\nYWwtbWFjaGluZS5sb2NhbDEnMCUGA1UECxMeTGluYXJvQ0EgRGV2aWNlIENlcnQg\nLSBTaWduaW5nMS0wKwYDVQQDEyRjNTJmN2Y4NS04ZmYwLTQzOGQtOGEwNi05Mzlj\nOWJlNTlhNGYwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARrMDR1HgkP/ET4yNqG\nM5km89r2DFAAKZDyL2lVg3C8sjNVrxoR73G7nhC8EyCFMwrIMK99O92tGFWOWqaM\nb2r9o0IwQDAdBgNVHQ4EFgQUDBH9jc9zvi3un83TFPI/tHhMF8YwHwYDVR0jBBgw\nFoAU+m+L2p3gV7JPexhVX6PFWMFy9cowCgYIKoZIzj0EAwIDSAAwRQIgM5zSdrUY\n7f0QG3cq+5MVL/rAb4k4Ok6vQIE63zRwQt8CIQCsQ7NQV9Sk8y3YU0R3HGUlOOMI\nKKmII4ZjIWrZs7Qr/A==\n-----END CERTIFICATE-----\n"
+}
+```
 
 # Mutual TLS Test Server
 

--- a/cadb/queries.go
+++ b/cadb/queries.go
@@ -104,6 +104,20 @@ func (conn *Conn) AddCert(id string, name string, serial *big.Int, keyId []byte,
 	return err
 }
 
+// GetCertBySerial gets certificate for the given serial.
+func (conn *Conn) GetCertBySerial(serial *big.Int) ([]byte, error) {
+	var cert []byte
+
+	if err := conn.db.QueryRow("SELECT cert FROM certs WHERE valid = 1 AND serial = ?",
+		serial.String()).Scan(&cert); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("serial %d: unknown certificate", serial)
+		}
+		return nil, fmt.Errorf("serial %d: %s", serial, err)
+	}
+	return cert, nil
+}
+
 // SerialValid checks if a valid certificate exists for the specified serial
 func (conn *Conn) SerialValid(serial *big.Int) (bool, error) {
 	var valid bool

--- a/caserver/caserver.go
+++ b/caserver/caserver.go
@@ -42,7 +42,8 @@ func crPost(w http.ResponseWriter, r *http.Request) {
 	case "application/cbor":
 		use_cbor = true
 	case "application/json":
-		//
+	case "":
+		// Default to JSON if not Content-Type provided (curl, etc.)
 	default:
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(`{"error": "Bad request: Content-Type must be application/cbor or application/json"}`))
@@ -195,7 +196,8 @@ func csGet(w http.ResponseWriter, r *http.Request) {
 	case "application/cbor":
 		use_cbor = true
 	case "application/json":
-		//
+	case "":
+		// Default to JSON if not Content-Type provided (curl, etc.)
 	default:
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(`{"error": "bad request: Content-Type must be application/cbor or application/json"}`))

--- a/caserver/caserver.go
+++ b/caserver/caserver.go
@@ -406,6 +406,66 @@ func home(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("Linaro CA HTTP server\n"))
 }
 
+// X509 Certificate copy handler
+func ccGet(w http.ResponseWriter, r *http.Request) {
+	pathParams := mux.Vars(r)
+
+	// Check Content-Type request
+	use_cbor := false
+	switch r.Header.Get("Content-Type") {
+	case "application/cbor":
+		use_cbor = true
+	case "application/json":
+	case "":
+		// Default to JSON if not Content-Type provided (curl, etc.)
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error": "bad request: Content-Type must be application/cbor or application/json"}`))
+		return
+	}
+	// Parse serial number in request
+	serialNumber, ok := pathParams["serial"]
+	ser := new(big.Int)
+	ser, ok = ser.SetString(serialNumber, 10)
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error": "invalid request"}`))
+		return
+	}
+
+	cert, err := db.GetCertBySerial(ser)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error": "invalid serial number"}`))
+		fmt.Println("cs:", err)
+		return
+	}
+
+	// Convert DER output to PEM
+	pemout := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert})
+
+	// CBOR response handler
+	if use_cbor {
+		w.Header().Set("Content-Type", "application/cbor")
+		w.WriteHeader(http.StatusOK)
+		enc := cbor.NewEncoder(w)
+		enc.Encode(protocol.CCResponse{
+			Status: 0,
+			Cert:   string(pemout),
+		})
+		fmt.Println(w)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	enc := json.NewEncoder(w)
+	err = enc.Encode(protocol.CCResponse{
+		Status: 0,
+		Cert:   string(pemout),
+	})
+}
+
 // Start the HTTP Server
 func Start(port int16) {
 	var err error
@@ -435,6 +495,7 @@ func Start(port int16) {
 	api.HandleFunc("/kur", kurPost).Methods(http.MethodPost)
 	api.HandleFunc("/krr", krrPost).Methods(http.MethodPost)
 	api.HandleFunc("/ccs", ccsGet).Methods(http.MethodGet)
+	api.HandleFunc("/cc/{serial}", ccGet).Methods(http.MethodGet)
 	api.HandleFunc("", notFound)
 
 	// Handle standard requests. Routes are tested in the order they are added,

--- a/cbor_decoder.go
+++ b/cbor_decoder.go
@@ -1,0 +1,111 @@
+//go:build never
+// +build never
+
+// Utility program helps to decode the cbor encoded binary output, focused
+// mainly decode curl command with Rest API request with CBOR format response,
+// refer to the readme for more information.
+//
+// This program expects two command-line argument
+// 	-`-i filename`: CBOR encoded binary input file.
+// 	-`-r resFmt`: Supported formats "cc", "cs", "ds", "csr" ,"ccs.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/fxamacker/cbor/v2"
+	"github.com/microbuilder/linaroca/protocol"
+	"io/ioutil"
+	"os"
+)
+
+var (
+	inFile = flag.String("i", "cbor_enc.raw", "Input CBOR encoded file in binary format")
+	resFmt = flag.String("r", "", "Expected protocol response format")
+)
+
+func main() {
+	flag.Parse()
+
+	// Use switch on the resFmt variable.
+	switch *resFmt {
+	case "cc":
+		var ccResponse protocol.CCResponse
+		err := decode(&ccResponse)
+		if err != nil {
+			fmt.Printf("Failure: %v\n", err)
+			goto ERROR
+		}
+	case "cs":
+		var csResponse protocol.CertStatusResponse
+		err := decode(&csResponse)
+		if err != nil {
+			fmt.Printf("Failure: %v\n", err)
+			goto ERROR
+		}
+	case "ds":
+		var dsResponse protocol.DevStatusResponse
+		err := decode(&dsResponse)
+		if err != nil {
+			fmt.Printf("Failure: %v\n", err)
+			goto ERROR
+		}
+	case "csr":
+		var csrResponse protocol.CSRResponse
+		err := decode(&csrResponse)
+		if err != nil {
+			fmt.Printf("Failure: %v\n", err)
+			goto ERROR
+		}
+	case "ccs":
+		var ccsResponse protocol.CCSResponse
+		err := decode(&ccsResponse)
+		if err != nil {
+			fmt.Printf("Failure: %v\n", err)
+			goto ERROR
+		}
+	case "":
+		fmt.Println("Missing protocol response format argument")
+		goto ERROR
+	}
+
+	return
+ERROR:
+	os.Exit(1)
+
+}
+
+func decode(v interface{}) error {
+	inp, err := os.Open(*inFile)
+	if err != nil {
+		return err
+	}
+	defer inp.Close()
+
+	raw, err := ioutil.ReadAll(inp)
+	if err != nil {
+		return err
+	}
+
+	// Decode to get response struct
+	dec := cbor.NewDecoder(bytes.NewReader(raw))
+	if err := dec.Decode(v); err != nil {
+		if err != nil {
+			fmt.Println("error:", err)
+		}
+		fmt.Println(err)
+	}
+
+	// Convert struct to json format
+	data, err := json.Marshal(v)
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+
+	fmt.Printf("%s\n", data)
+
+	return nil
+}

--- a/protocol/cc.go
+++ b/protocol/cc.go
@@ -1,0 +1,6 @@
+package protocol // github.com/microbuilder/linaroca/protocol
+
+type CCResponse struct {
+	Status int    `cbor:"1,keyasint"`
+	Cert   string `cbor:"2,keyasint"`
+}


### PR DESCRIPTION
- Add new database query support to retrieve the X509 certificate for the given serial number.
- Add new `api/v1/cc/{serial}` rest API support .
- Add a new section describe about x509 certificate copy request using the rest API.
fixes #46 