### PR TITLE
Remove the hostname from the device cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ The hostname is important since it will be included in the subject line of
 certificates signed by liteboot, and be part of the SERVER certificate used to
 establish a TLS connection to the server.
 
-The **same hostname** must be used in the SERVER certificate, and in the
-subject line of DEVICE certificates, or the TLS connection will be refused.
+The **same hostname** must be used in the SERVER certificate or the
+TLS connection will be refused.
 
 This application will attempt to determine the hostname to use for the
 server(s) based on the following order of precedence:

--- a/new-device.sh
+++ b/new-device.sh
@@ -106,6 +106,7 @@ fi
 # that here.
 DEVID=$(uuidgen | tr '[:upper:]' '[:lower:]')
 DEVPATH=certs/$DEVID
+DEVVENDOR="Test Vendor"
 
 echo New device: "$DEVID"
 
@@ -116,7 +117,7 @@ openssl ecparam -name prime256v1 -genkey -out "$DEVPATH.key"
 openssl req -new \
 	-key "$DEVPATH.key" \
 	-out "$DEVPATH.csr" \
-	-subj "/O=$HOSTNAME/CN=$DEVID/OU=LinaroCA Device Cert - Signing"
+	-subj "/O=$DEVVENDOR/CN=$DEVID/OU=LinaroCA Device Cert - Signing"
 
 # Convert this CSR to cbor.
 go run make_csr_cbor.go -in "$DEVPATH.csr" -out "$DEVPATH.cbor"


### PR DESCRIPTION
It is misleading to have the hostname that the CA server runs on on the device cert. If it were actually checked, it would mean that the devices could only be running on the server.

Change this to a sample vendor name, with the option to set to a vendor name in the future.

Signed-off-by: David Brown <david.brown@linaro.org>