### PR TITLE
scripts: new-device: Subject line cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,8 +553,8 @@ mTLS connections via:
 
 ```bash
 $ openssl s_client \
-  -cert certs/a8c6f808-b659-4f88-affb-40498834c572.crt \
-  -key certs/a8c6f808-b659-4f88-affb-40498834c572.key \
+  -cert certs/f269528d-ff66-4fb0-83d8-e449e0038010.crt \
+  -key certs/f269528d-ff66-4fb0-83d8-e449e0038010.key \
   -CAfile certs/CA.crt \
   -connect MBP2021.lan:8443
 ```
@@ -575,12 +575,17 @@ And liteboot will display details about the client cert in the log output:
 $ ./liteboot server start
 Starting mTLS TCP server on MBP2021.lan:8443
 Starting CA server on port https://MBP2021.lan:1443
-Connection accepted from 127.0.0.1:50231
-Client certificate:
-- Issuer CN: LRC - 20220330062226
-- Subject: CN=a8c6f808-b659-4f88-affb-40498834c572,
-  OU=LinaroCA Device Cert - Signing,O=MBP2021.lan
+Connection accepted from 127.0.0.1:60510
+[Certificate 0]
+  - Subject: CN=f269528d-ff66-4fb0-83d8-e449e0038010,OU=Signing,O=Linaro\, LTD
+  - Serial:  1671014018808547000
+[Certificate 1]
+  - Subject: CN=LRC - 20221129052020,O=Linaro\, LTD
+  - Serial:  2022001129172020
 ```
+
+- `Certificate 0` is the device certificate
+- `Certificate 1` is the CA certificate used to sign certificate 0.
 
 ### Using an invalid client certificate
 
@@ -602,7 +607,8 @@ $ openssl s_client \
   -connect MBP2021.lan:8443
 ```
 
-You should get the following error from liteboot:
+You should get the following error from liteboot, since the device certificate
+has not been signed by our CA:
 
 ```
 Connection accepted from 127.0.0.1:50443

--- a/new-device.sh
+++ b/new-device.sh
@@ -48,14 +48,10 @@ You can view the content of the certificate via:
 
 HOSTNAME
 --------
-A consistent hostname must be used in your network layout, since the name will
-be included in the generated device certificate, and the TLS handshake will
-fail if the hostname used by the device certificate and the server certificate
-don't match.
+A consistent hostname must be used in your network layout or the TLS handshake
+will fail.
 
-For this script, which generates a device certificate that includes the
-hostname in the ORG field of the certificate subject, you can set the hostname
-value through several mechanism:
+For this script, you can set the hostname value through several mechanism:
 
    1. Via the '[hostname]' parameter when calling this script, i.e.:
 
@@ -102,7 +98,7 @@ if [ $# -eq 1 ]
     HOSTNAME=${CAHOSTNAME:-$(hostname)}
 fi
 
-# Generate a device ID.  BSD's uuidgen outputs uppercase, so conver
+# Generate a device ID.  BSD's uuidgen outputs uppercase, so convert
 # that here.
 DEVID=$(uuidgen | tr '[:upper:]' '[:lower:]')
 DEVPATH=certs/$DEVID
@@ -117,7 +113,7 @@ openssl ecparam -name prime256v1 -genkey -out "$DEVPATH.key"
 openssl req -new \
 	-key "$DEVPATH.key" \
 	-out "$DEVPATH.csr" \
-	-subj "/O=$DEVVENDOR/CN=$DEVID/OU=LinaroCA Device Cert - Signing"
+	-subj "/O=$DEVVENDOR/CN=$DEVID/OU=Signing"
 
 # Convert this CSR to cbor.
 go run make_csr_cbor.go -in "$DEVPATH.csr" -out "$DEVPATH.cbor"


### PR DESCRIPTION
Further cleanup, removing the hostname references from the help menu, and simplifying the `OU` field to a single verb (`SIGNING` by default) to indicate certificate intent.

This is a minor follow-up to #55 